### PR TITLE
Update order submission endpoint to support latest Smart contracts and API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arrow-markets/arrow-sdk",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "This SDK is meant to make it easier for developers to connect to the Arrow API.",
     "main": "lib/src/arrow-sdk.js",
     "types": "lib/src/arrow-sdk.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arrow-markets/arrow-sdk",
-    "version": "1.4.2",
+    "version": "1.4.1",
     "description": "This SDK is meant to make it easier for developers to connect to the Arrow API.",
     "main": "lib/src/arrow-sdk.js",
     "types": "lib/src/arrow-sdk.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arrow-markets/arrow-sdk",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "This SDK is meant to make it easier for developers to connect to the Arrow API.",
     "main": "lib/src/arrow-sdk.js",
     "types": "lib/src/arrow-sdk.d.ts",

--- a/src/arrow-sdk.ts
+++ b/src/arrow-sdk.ts
@@ -353,8 +353,9 @@ export async function submitLongOptionOrder(
         })
     })
 
+    const apiEndPoint = deliverOptionParams[0].orderType === OrderType.LONG_OPEN ? '/open-long-position' : '/close-long-position'
     const orderSubmissionResponse = await axios.post(
-        urls.api[version] + '/submit-order',
+        urls.api[version] + apiEndPoint,
         {
             'params': params!
         }

--- a/src/arrow-sdk.ts
+++ b/src/arrow-sdk.ts
@@ -341,7 +341,6 @@ export async function submitLongOptionOrder(
     deliverOptionParams.map(order => {
         params.push(
         {
-            'order_type': order.orderType,
             'ticker': order.ticker,
             'expiration': order.expiration,
             'strike': order.formattedStrike,
@@ -373,32 +372,33 @@ export async function submitLongOptionOrder(
  * @returns Data object from API response that includes transaction hash and per-option execution price of the option transaction.
  */
 export async function submitShortOptionOrder(
-    deliverOptionParams: DeliverOptionParams,
+    deliverOptionParams: DeliverOptionParams[],
     version = DEFAULT_VERSION
 ) {
     if (!isValidVersion(version)) throw UNSUPPORTED_VERSION_ERROR
 
-    if(
-        deliverOptionParams.orderType === OrderType.SHORT_CLOSE && 
-        deliverOptionParams.payPremium === undefined
-    ) {
-        throw new Error('Must provide all of the order parameters')
-    }
-  
-    const orderEndpoint = deliverOptionParams.orderType === 2 ? "/open-short-position" : "/close-short-position"
+    // Submit multiple option orders through API
+    let params: any[] = []
+
+    deliverOptionParams.map(order => {
+        params.push(
+        {
+            'ticker': order.ticker,
+            'expiration': order.expiration,
+            'strike': order.formattedStrike,
+            'contract_type': order.contractType,
+            'quantity': order.quantity,
+            'threshold_price': order.bigNumberThresholdPrice.toString(),
+            'hashed_params': order.hashedValues,
+            'signature': order.signature
+        })
+    })
+
+    const orderEndpoint = deliverOptionParams[0].orderType === 2 ? "/open-short-position" : "/close-short-position"
     const orderSubmissionResponse = await axios.post(
         urls.api[version] + orderEndpoint,
         {   
-            pay_premium: deliverOptionParams.payPremium,
-            order_type: deliverOptionParams.orderType,
-            ticker: deliverOptionParams.ticker,
-            expiration: deliverOptionParams.expiration,
-            strike: deliverOptionParams.formattedStrike,
-            contract_type: deliverOptionParams.contractType,
-            quantity: deliverOptionParams.quantity,
-            threshold_price: deliverOptionParams.bigNumberThresholdPrice.toString(),
-            hashed_params: deliverOptionParams.hashedValues,
-            signature: deliverOptionParams.signature
+            'params': params
         }
     )
 


### PR DESCRIPTION
# Description

Updates the `submitLongOptionOrder` and `submitShortOptionOrder` functions to use the updates API endpoint accordingly. 
`submitLongOptionOrder` uses `/open-long-position` for `LONG_OPEN` order type
`submitLongOptionOrder` uses `/close-long-position` for `LONG_CLOSE` order type
`submitShortOptionOrder` uses `/open-short-position` for `SHORT_OPEN` order type
`submitShortOptionOrder` uses `/close-short-position` for `SHORT_CLOSE` order type

`submitShortOptionOrder` now also supports an array of option order params, allowing users to open or close multiple short positions in one transaction. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Tested by integrating with a local instance of API, UI and smart contracts. 
The only issue I am facing is the following error:
`Option order submission failed on the blockchain: {'code': -32000, 'message': 'insufficient funds for gas * price + value: address 0xc33C0dE888B48123Da2d6b4B4b4E644Ae2c688A8 have (917104310552799930) want (8000000000000000000)'}`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] New and existing unit tests pass locally with my changes - I would like to confirm the error above is unrelated to SDK or API changes by testing on with the live server account.
- [x] Any dependent changes have been merged and published in downstream modules
